### PR TITLE
Added missing phy gpio

### DIFF
--- a/include/cfn_hal_comp.h
+++ b/include/cfn_hal_comp.h
@@ -35,6 +35,7 @@ extern "C"
 #include "cfn_hal_types.h"
 #include "cfn_hal.h"
 #include "cfn_hal_base.h"
+#include "cfn_hal_gpio.h"
 
 /* Defines ----------------------------------------------------------*/
 
@@ -74,8 +75,11 @@ typedef enum
  */
 typedef struct
 {
-    void *instance; /*!< Peripheral base instance */
-    void *user_arg; /*!< Peripheral instance user argument */
+    void                      *instance;    /*!< Peripheral base instance */
+    cfn_hal_gpio_pin_handle_t *input_plus;  /*!< Non-inverting input pin mapping */
+    cfn_hal_gpio_pin_handle_t *input_minus; /*!< Inverting input pin mapping */
+    cfn_hal_gpio_pin_handle_t *output;      /*!< Comparator output pin mapping */
+    void                      *user_arg;    /*!< Peripheral instance user argument */
 } cfn_hal_comp_phy_t;
 
 /**

--- a/include/cfn_hal_eth.h
+++ b/include/cfn_hal_eth.h
@@ -35,6 +35,7 @@ extern "C"
 #include "cfn_hal_types.h"
 #include "cfn_hal.h"
 #include "cfn_hal_base.h"
+#include "cfn_hal_gpio.h"
 
 /* Defines ----------------------------------------------------------*/
 
@@ -108,8 +109,17 @@ typedef struct
  */
 typedef struct
 {
-    void *instance; /*!< Peripheral base instance */
-    void *user_arg; /*!< Peripheral instance user argument */
+    void                      *instance; /*!< Peripheral base instance */
+    cfn_hal_gpio_pin_handle_t *ref_clk;  /*!< Reference clock mapping */
+    cfn_hal_gpio_pin_handle_t *mdio;     /*!< Management Data I/O mapping */
+    cfn_hal_gpio_pin_handle_t *mdc;      /*!< Management Data Clock mapping */
+    cfn_hal_gpio_pin_handle_t *crs_dv;   /*!< Carrier Sense/Data Valid mapping */
+    cfn_hal_gpio_pin_handle_t *rxd0;     /*!< Receive Data 0 mapping */
+    cfn_hal_gpio_pin_handle_t *rxd1;     /*!< Receive Data 1 mapping */
+    cfn_hal_gpio_pin_handle_t *tx_en;    /*!< Transmit Enable mapping */
+    cfn_hal_gpio_pin_handle_t *txd0;     /*!< Transmit Data 0 mapping */
+    cfn_hal_gpio_pin_handle_t *txd1;     /*!< Transmit Data 1 mapping */
+    void                      *user_arg; /*!< Peripheral instance user argument */
 } cfn_hal_eth_phy_t;
 
 typedef struct cfn_hal_eth_s     cfn_hal_eth_t;

--- a/include/cfn_hal_i2s.h
+++ b/include/cfn_hal_i2s.h
@@ -35,6 +35,7 @@ extern "C"
 #include "cfn_hal_types.h"
 #include "cfn_hal.h"
 #include "cfn_hal_base.h"
+#include "cfn_hal_gpio.h"
 
 /* Defines ----------------------------------------------------------*/
 
@@ -78,8 +79,13 @@ typedef struct
  */
 typedef struct
 {
-    void *instance; /*!< Peripheral base instance */
-    void *user_arg; /*!< Peripheral instance user argument */
+    void                      *instance; /*!< Peripheral base instance */
+    cfn_hal_gpio_pin_handle_t *ck;       /*!< Continuous Serial Clock mapping */
+    cfn_hal_gpio_pin_handle_t *ws;       /*!< Word Select mapping */
+    cfn_hal_gpio_pin_handle_t *sd;       /*!< Serial Data mapping */
+    cfn_hal_gpio_pin_handle_t *ext_sd;   /*!< Full-duplex Serial Data mapping */
+    cfn_hal_gpio_pin_handle_t *mck;      /*!< Master Clock mapping */
+    void                      *user_arg; /*!< Peripheral instance user argument */
 } cfn_hal_i2s_phy_t;
 
 typedef struct cfn_hal_i2s_s     cfn_hal_i2s_t;

--- a/include/cfn_hal_qspi.h
+++ b/include/cfn_hal_qspi.h
@@ -35,6 +35,7 @@ extern "C"
 #include "cfn_hal_types.h"
 #include "cfn_hal.h"
 #include "cfn_hal_base.h"
+#include "cfn_hal_gpio.h"
 
 /* Defines ----------------------------------------------------------*/
 
@@ -103,8 +104,14 @@ typedef struct
  */
 typedef struct
 {
-    void *instance; /*!< Peripheral base instance */
-    void *user_arg; /*!< Peripheral instance user argument */
+    void                      *instance; /*!< Peripheral base instance */
+    cfn_hal_gpio_pin_handle_t *clk;      /*!< Clock signal mapping */
+    cfn_hal_gpio_pin_handle_t *cs;       /*!< Chip Select mapping */
+    cfn_hal_gpio_pin_handle_t *io0;      /*!< Data I/O 0 mapping */
+    cfn_hal_gpio_pin_handle_t *io1;      /*!< Data I/O 1 mapping */
+    cfn_hal_gpio_pin_handle_t *io2;      /*!< Data I/O 2 mapping */
+    cfn_hal_gpio_pin_handle_t *io3;      /*!< Data I/O 3 mapping */
+    void                      *user_arg; /*!< Peripheral instance user argument */
 } cfn_hal_qspi_phy_t;
 
 typedef struct cfn_hal_qspi_s     cfn_hal_qspi_t;

--- a/include/cfn_hal_sdio.h
+++ b/include/cfn_hal_sdio.h
@@ -35,6 +35,7 @@ extern "C"
 #include "cfn_hal_types.h"
 #include "cfn_hal.h"
 #include "cfn_hal_base.h"
+#include "cfn_hal_gpio.h"
 
 /* Defines ----------------------------------------------------------*/
 
@@ -105,8 +106,14 @@ typedef struct
  */
 typedef struct
 {
-    void *instance; /*!< Peripheral base instance */
-    void *user_arg; /*!< Peripheral instance user argument */
+    void                      *instance; /*!< Peripheral base instance */
+    cfn_hal_gpio_pin_handle_t *ck;       /*!< Clock mapping */
+    cfn_hal_gpio_pin_handle_t *cmd;      /*!< Command mapping */
+    cfn_hal_gpio_pin_handle_t *d0;       /*!< Data 0 mapping */
+    cfn_hal_gpio_pin_handle_t *d1;       /*!< Data 1 mapping */
+    cfn_hal_gpio_pin_handle_t *d2;       /*!< Data 2 mapping */
+    cfn_hal_gpio_pin_handle_t *d3;       /*!< Data 3 mapping */
+    void                      *user_arg; /*!< Peripheral instance user argument */
 } cfn_hal_sdio_phy_t;
 
 typedef struct cfn_hal_sdio_s     cfn_hal_sdio_t;

--- a/include/cfn_hal_usb.h
+++ b/include/cfn_hal_usb.h
@@ -37,6 +37,7 @@ extern "C"
 #include "cfn_hal_types.h"
 #include "cfn_hal.h"
 #include "cfn_hal_base.h"
+#include "cfn_hal_gpio.h"
 
 /* Defines ----------------------------------------------------------*/
 
@@ -94,8 +95,12 @@ typedef struct
  */
 typedef struct
 {
-    void *instance; /*!< Peripheral base instance (e.g. USB_OTG_FS) */
-    void *user_arg; /*!< Peripheral instance user argument */
+    void                      *instance; /*!< Peripheral base instance (e.g. USB_OTG_FS) */
+    cfn_hal_gpio_pin_handle_t *dp;       /*!< Data+ pin mapping */
+    cfn_hal_gpio_pin_handle_t *dm;       /*!< Data- pin mapping */
+    cfn_hal_gpio_pin_handle_t *id;       /*!< ID pin mapping (OTG) */
+    cfn_hal_gpio_pin_handle_t *vbus;     /*!< VBUS sensing pin mapping */
+    void                      *user_arg; /*!< Peripheral instance user argument */
 } cfn_hal_usb_phy_t;
 
 typedef struct cfn_hal_usb_s     cfn_hal_usb_t;


### PR DESCRIPTION
Added missing gpios inside the phy struct for multiple peripherals

	include/cfn_hal_comp.h
	include/cfn_hal_eth.h
	include/cfn_hal_i2s.h
	include/cfn_hal_qspi.h
	include/cfn_hal_sdio.h
        include/cfn_hal_usb.h

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
