### PR TITLE
Expand I2C and SPI with device

### DIFF
--- a/include/cfn_hal_i2c.h
+++ b/include/cfn_hal_i2c.h
@@ -135,6 +135,16 @@ typedef struct
 } cfn_hal_i2c_mem_transaction_t;
 
 typedef struct cfn_hal_i2c_s     cfn_hal_i2c_t;
+
+/**
+ * @brief I2C Device addressing association.
+ */
+typedef struct
+{
+    cfn_hal_i2c_t *i2c;     /*!< Pointer to the underlying I2C driver */
+    uint16_t       address; /*!< 7-bit or 10-bit target address */
+} cfn_hal_i2c_device_t;
+
 typedef struct cfn_hal_i2c_api_s cfn_hal_i2c_api_t;
 
 /**

--- a/include/cfn_hal_i2c.h
+++ b/include/cfn_hal_i2c.h
@@ -134,7 +134,7 @@ typedef struct
     size_t   size;          /*!< Bytes to transfer */
 } cfn_hal_i2c_mem_transaction_t;
 
-typedef struct cfn_hal_i2c_s     cfn_hal_i2c_t;
+typedef struct cfn_hal_i2c_s cfn_hal_i2c_t;
 
 /**
  * @brief I2C Device addressing association.

--- a/include/cfn_hal_spi.h
+++ b/include/cfn_hal_spi.h
@@ -127,6 +127,16 @@ typedef struct
 } cfn_hal_spi_transaction_t;
 
 typedef struct cfn_hal_spi_s     cfn_hal_spi_t;
+
+/**
+ * @brief SPI Device addressing association.
+ */
+typedef struct
+{
+    cfn_hal_spi_t             *spi;    /*!< Pointer to the underlying SPI driver */
+    cfn_hal_gpio_pin_handle_t *cs_pin; /*!< Chip Select pin handle */
+} cfn_hal_spi_device_t;
+
 typedef struct cfn_hal_spi_api_s cfn_hal_spi_api_t;
 
 /**

--- a/include/cfn_hal_spi.h
+++ b/include/cfn_hal_spi.h
@@ -126,7 +126,7 @@ typedef struct
     cfn_hal_gpio_pin_handle_t *cs;           /*!< Target CS driver mapping if HAL controlled */
 } cfn_hal_spi_transaction_t;
 
-typedef struct cfn_hal_spi_s     cfn_hal_spi_t;
+typedef struct cfn_hal_spi_s cfn_hal_spi_t;
 
 /**
  * @brief SPI Device addressing association.

--- a/include/cfn_hal_types.h
+++ b/include/cfn_hal_types.h
@@ -77,6 +77,7 @@ typedef enum cfn_hal_error_codes
     CFN_HAL_ERROR_MEMORY_ALLOC,
     CFN_HAL_ERROR_MEMORY_EMPTY,
 
+
     CFN_HAL_ERROR_UNKNOWN
 } cfn_hal_error_code_t;
 

--- a/include/cfn_hal_types.h
+++ b/include/cfn_hal_types.h
@@ -77,7 +77,6 @@ typedef enum cfn_hal_error_codes
     CFN_HAL_ERROR_MEMORY_ALLOC,
     CFN_HAL_ERROR_MEMORY_EMPTY,
 
-
     CFN_HAL_ERROR_UNKNOWN
 } cfn_hal_error_code_t;
 


### PR DESCRIPTION
Introduced cfn_hal_i2c_device_t and cfn_hal_spi_device_t to ensure type-safe hardware addressing, replacing the previous void* casting pattern.

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
